### PR TITLE
🎨 Palette: Add Accessible Text to External Social Links

### DIFF
--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -1,0 +1,21 @@
+{{ with .Site.Params.social }}
+<ul>
+  {{ range sort . "weight" }}
+    {{ if .icon }}
+      <li>
+        <a href="{{ .url | safeURL }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }} {{ if .type }}type="{{ .type }}"{{ end }}>
+          <i class="{{ .icon }}" aria-hidden="true"></i>
+          {{- if .target -}}<span class="sr-only"> (opens in a new tab)</span>{{- end -}}
+        </a>
+      </li>
+    {{ else }}
+      <li>
+        <a href="{{ .url | safeURL }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }}>
+          {{- .name -}}
+          {{- if .target -}}<span class="sr-only"> (opens in a new tab)</span>{{- end -}}
+        </a>
+      </li>
+    {{ end }}
+  {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
This change introduces an accessibility improvement to the social media links. It overrides the `social.html` partial to include a visually hidden `<span>` that announces "(opens in a new tab)" for any link configured with `target="_blank"`. This provides important context for screen reader users, improving their navigation experience. The change is dormant until a link is configured to open in a new tab.

---
*PR created automatically by Jules for task [2938035972830477844](https://jules.google.com/task/2938035972830477844) started by @vrutkovs*